### PR TITLE
Parameterize Tree

### DIFF
--- a/src/Terms.jl
+++ b/src/Terms.jl
@@ -1,6 +1,7 @@
 module Terms
 
 include("types.jl")
+include("pool.jl")
 
 include("substitution.jl")
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -1,0 +1,25 @@
+export Pool
+
+
+struct Pool{T}
+    ids::Dict{T,UInt}
+    lookup::Vector{T}
+    Pool{T}() where {T} = new{T}(Dict{T,UInt}(), T[])
+end
+
+Base.push!(p::Pool, ex) = Term{UInt}(expr_to_tree(to_pool(p), UInt, ex))
+Base.getindex(p::Pool, t::Term) = tree_to_expr(from_pool(p), t.tree)
+
+
+to_pool(p::Pool) = Base.Fix1(to_pool, p)
+function to_pool(p::Pool, x)
+    haskey(p.ids, x) && return p.ids[x]
+
+    push!(p.lookup, x)
+    index = UInt(length(p.lookup))
+    p.ids[x] = index
+    return index
+end
+
+from_pool(p::Pool) = Base.Fix1(from_pool, p)
+from_pool(p::Pool, index::UInt) = p.lookup[index]

--- a/src/substitution.jl
+++ b/src/substitution.jl
@@ -11,16 +11,15 @@ Base.iterate(σ::Substitution) = iterate(σ.dict)
 Base.iterate(σ::Substitution, state) = iterate(σ.dict, state)
 Base.keys(σ::Substitution) = keys(σ.dict)
 Base.getindex(σ::Substitution, keys...) = getindex(σ.dict, keys...)
-Base.setindex!(σ::Substitution, val, keys...) = setindex!(σ.dict, val, keys...)
+Base.setindex!(σ::Substitution, val, keys...) = (setindex!(σ.dict, val, keys...); σ)
 Base.get(σ::Substitution, key, default) = get(σ.dict, key, default)
-Base.broadcastable(σ::Substitution) = Ref(σ)
 
 
-Base.replace(t::Term, σ::AbstractDict) = Term(replace(t.tree, σ), t.pool)
-function Base.replace(t::Tree, σ::AbstractDict)
-    isa(t, Variable) && return get(σ, t, t)
-    Node(t.head, replace.(t.args, σ))
-end
+Base.replace(t::Term{T}, σ::AbstractDict) where {T} = Term{T}(replace(t.tree, σ))
+Base.replace(t::Tree{T}, σ::AbstractDict) where {T} =
+    isa(t, Variable) ? get(σ, t, t) :
+    isa(t, Node)     ? Node{T}(t.head, replace.(t.args, Ref(σ))) :
+    t
 
 
 """
@@ -29,30 +28,25 @@ end
 Syntactically match term `subject` to `pattern`, producing a `Substitution` if the
 process succeeds and `nothing` otherwise.
 """
-function Base.match(pattern::Term, subject::Term)
-    pattern.pool === subject.pool ||
-        throw(ArgumentError("pattern and subject must have same pool"))
-
+Base.match(pattern::Term, subject::Term) =
     _match!(Substitution(), pattern.tree, subject.tree)
-end
 
 function _match!(σ::Substitution, p, s)
     if isa(p, Variable)
-        haskey(σ, p) && σ[p] != s && return nothing
-        σ[p] = s
-        return σ
+        haskey(σ, p) && (isequal(σ[p], s) || return)
+        return setindex!(σ, s, p)  # σ[p] = s
     end
-
-    isa(s, Node) || return nothing
-
     # @assert isa(p, Node)
-    p.head === s.head                || return nothing
-    length(p.args) == length(s.args) || return nothing
 
-    # @assert isa(p.head, Symbol)
+    isa(s, Node) || return
+    # @assert isa(s, Node)
+
+    isequal(p.head, s.head)          || return
+    length(p.args) == length(s.args) || return
+
     for (x, y) ∈ zip(p.args, s.args)
         σ′ = _match!(σ, x, y)
-        σ′ === nothing && return nothing
+        σ′ === nothing && return
         σ = σ′
     end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,40 +1,21 @@
-export Variable, Pool, Term
+export Variable, Term
 
 
 mutable struct Variable end
 
 
-struct Node
-    head::Union{Symbol, UInt}
-    args::Vector{Union{Node, Variable}}
+struct Node{T}
+    head::T
+    args::Vector{Union{Node{T}, Variable}}
 end
 Base.:(==)(s::Node, t::Node) = (s.head, s.args) == (t.head, t.args)
 
-const Tree = Union{Node, Variable}
-
-
-struct Pool{T}
-    ids::Dict{T,UInt}
-    lookup::Vector{T}
-    Pool{T}() where {T} = new{T}(Dict{T,UInt}(), T[])
-end
-Base.broadcastable(p::Pool) = Ref(p)
-function Base.push!(p::Pool, x)
-    haskey(p.ids, x) && return p.ids[x]
-
-    push!(p.lookup, x)
-    index = UInt(length(p.lookup))
-    p.ids[x] = index
-    return index
-end
-Base.getindex(p::Pool, index::UInt) = p.lookup[index]
-
+const Tree{T} = Union{Node{T}, Variable}
 
 struct Term{T}
-    tree::Tree
-    pool::Pool{T}
+    tree::Tree{T}
 end
-(p::Pool)(ex) = Term(expr_to_tree(p, ex), p)
+Base.convert(::Type{Term{T}}, ex) where {T} = Term{T}(expr_to_tree(T, ex))
+Base.convert(::Type{Term{T}}, t::Term{T}) where {T} = t
 Base.convert(::Type{Expr}, t::Term) = term_to_expr(t)
-
-Base.:(==)(s::Term, t::Term) = s.pool === t.pool && s.tree == t.tree
+Base.:(==)(s::Term, t::Term) = s.tree == t.tree

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,5 +17,5 @@ struct Term{T}
 end
 Base.convert(::Type{Term{T}}, ex) where {T} = Term{T}(expr_to_tree(T, ex))
 Base.convert(::Type{Term{T}}, t::Term{T}) where {T} = t
-Base.convert(::Type{Expr}, t::Term) = term_to_expr(t)
+Base.convert(::Type{Expr}, t::Term) = tree_to_expr(t.tree)
 Base.:(==)(s::Term, t::Term) = s.tree == t.tree

--- a/src/util.jl
+++ b/src/util.jl
@@ -4,8 +4,8 @@ export head, children
 @inline head(t::Tree) = isa(t, Node) ? t.head : t
 @inline head(t::Term) = head(t.tree)
 
-@inline children(t::Tree) = isa(t, Node) ? t.args : Tree[]
-@inline children(t::Term) = Term.(children(t.tree))
+@inline children(t::Tree) = isa(t, Node) ? t.args : []
+@inline children(t::Term{T}) where {T} = Term{T}.(children(t.tree))
 
 
 function expr_to_tree(T, x)::Tree

--- a/src/util.jl
+++ b/src/util.jl
@@ -8,27 +8,29 @@ export head, children
 @inline children(t::Term{T}) where {T} = Term{T}.(children(t.tree))
 
 
-function expr_to_tree(T, x)::Tree
+function expr_to_tree(f::Function, T, x)::Tree
     isa(x, Variable) && return x
 
     if isa(x, Expr)
         args = similar(x.args, Tree{T})
         for i ∈ eachindex(x.args)
-            args[i] = expr_to_tree(T, x.args[i])
+            args[i] = expr_to_tree(f, T, x.args[i])
         end
-        return Node{T}(x.head, args)
+        return Node{T}(f(x.head), args)
     end
 
-    return Node{T}(x, Tree{T}[])
+    return Node{T}(f(x), Tree{T}[])
 end
+expr_to_tree(T, x) = expr_to_tree(identity, T, x)
 
 
-term_to_expr(t::Term) = term_to_expr(t.tree)
-function term_to_expr(t::Tree)
+function tree_to_expr(f::Function, t::Tree)
     isa(t, Node) || return t
-    (isa(t.head, Symbol) && !isempty(t.args)) || return t.head
+    _head = f(t.head)
+    (isa(_head, Symbol) && !isempty(t.args)) || return _head
 
-    expr = Expr(t.head)
-    append!(expr.args, term_to_expr.(t.args))
+    expr = Expr(_head)
+    append!(expr.args, tree_to_expr.(f, t.args))
     return expr
 end
+tree_to_expr(t::Tree) = tree_to_expr(identity, t)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -8,38 +8,26 @@ using Test
     @test x ≠ y
 end
 
-@testset "Pool" begin
-    TermA = Pool{Union{Symbol, Int}}()
-    TermB = Pool{Union{Symbol, Int}}()
-    @test TermA == TermA
-    @test TermB == TermB
-    @test TermA ≠ TermB
-end
-
 @testset "Term" begin
-    TermA = Pool{Union{Symbol, Int}}()
+    TermA = Term{Union{Symbol, Int}}
     x = Variable()
 
-    @test TermA(:(x + 2y)) == TermA(:(x + 2y))
-    @test TermA(:(x + 2y)) ≠ TermA(:(x + 3y))
-    @test TermA(:(x + 2y)) ≠ TermA(:(x + 2z))
-    @test TermA(:(x + 2y)) ≠ TermA(:($x + 2y))
+    @test convert(TermA, :(x + 2y)) == convert(TermA, :(x + 2y))
+    @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :(x + 3y))
+    @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :(x + 2z))
+    @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :($x + 2y))
 
-    let TermB = Pool{Union{Symbol, Int}}()
-        @test TermA(:(x + 2y)) ≠ TermB(:(x + 2y))
-    end
-
-    function test_tree(b, ex::Expr, t)
+    function test_tree(ex::Expr, t)
         @test head(t) === ex.head
 
         ex_args = ex.args
         t_args = children(t)
         @test length(ex_args) == length(t_args)
 
-        test_tree.(b, ex_args, t_args)
+        test_tree.(ex_args, t_args)
         nothing
     end
-    function test_tree(b, x, t)
+    function test_tree(x, t)
         @test head(t) === x
         @test isempty(children(t))
         nothing
@@ -56,9 +44,9 @@ end
         :(a || (b && c)),
     ]
     @testset for expr ∈ exprs
-        term = TermA(expr)
+        term = convert(TermA, expr)
         @test convert(Expr, term) == expr
-        test_tree(TermA, expr, term)
+        test_tree(expr, term)
     end
 
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -5,48 +5,43 @@ using Test
 @testset "Variable" begin
     x = Variable()
     y = Variable()
+    @test x == x
     @test x ≠ y
 end
 
-@testset "Term" begin
+@testset "Node" begin
     TermA = Term{Union{Symbol, Int}}
     x = Variable()
 
-    @test convert(TermA, :(x + 2y)) == convert(TermA, :(x + 2y))
-    @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :(x + 3y))
-    @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :(x + 2z))
-    @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :($x + 2y))
-
-    function test_tree(ex::Expr, t)
-        @test head(t) === ex.head
-
-        ex_args = ex.args
-        t_args = children(t)
-        @test length(ex_args) == length(t_args)
-
-        test_tree.(ex_args, t_args)
-        nothing
-    end
-    function test_tree(x, t)
-        @test head(t) === x
-        @test isempty(children(t))
-        nothing
+    @testset "equality" begin
+        @test convert(TermA, :(x + 2y)) == convert(TermA, :(x + 2y))
+        @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :(x + 3y))
+        @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :(x + 2z))
+        @test convert(TermA, :(x + 2y)) ≠ convert(TermA, :($x + 2y))
     end
 
-    exprs = [
-        7,
-        x,
-        :(x + 2y),
-        :(f(x, g(y, z), h(g))),
-        :f,
-        :(f()),
-        :(identity(-)(5, 3)),
-        :(a || (b && c)),
-    ]
-    @testset for expr ∈ exprs
-        term = convert(TermA, expr)
-        @test convert(Expr, term) == expr
-        test_tree(expr, term)
+    @testset "shape" begin
+        function test_tree(ex::Expr, t)
+            @test head(t) === ex.head
+
+            ex_args = ex.args
+            t_args = children(t)
+            @test length(ex_args) == length(t_args)
+
+            test_tree.(ex_args, t_args)
+            nothing
+        end
+        function test_tree(x, t)
+            @test head(t) === x
+            @test isempty(children(t))
+            nothing
+        end
+
+        @testset for expr ∈ EXPRS
+            term = convert(TermA, expr)
+            @test convert(Expr, term) == expr
+            test_tree(expr, term)
+        end
     end
 
 end

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -1,0 +1,21 @@
+using Terms
+using Test
+
+
+@testset "equality" begin
+    pool1 = Pool{Union{Symbol, Int}}()
+    pool2 = Pool{Union{Symbol, Int}}()
+    @test pool1 == pool1
+    @test pool2 == pool2
+    @test pool1 ≠ pool2
+end
+
+@testset "conversion" begin
+    pool = Pool{Union{Symbol, Int}}()
+
+    @testset "$expr" for expr ∈ EXPRS
+        term = push!(pool, expr)
+        @test isa(term, Term{UInt})
+        @test pool[term] == expr
+    end
+end

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -19,3 +19,20 @@ end
         @test pool[term] == expr
     end
 end
+
+@testset "matching" begin
+    pool = Pool{Symbol}()
+    x, y = Variable(), Variable()
+
+    pattern_ = :($x * ($x + $y))
+    pattern = push!(pool, pattern_)
+
+    subject1 = :(a * (a + var))
+    σ₁ = match(pattern, push!(pool, subject1))
+    @test length(σ₁) == 2
+    @test pool[σ₁(pattern)] == subject1
+
+    subject2 = :(a * (b + var))
+    σ₂ = match(pattern, push!(pool, subject2))
+    @test σ₂ === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,22 @@
+using Terms
 using Test
 
-@testset "Basic" begin include("basic.jl") end
+
+x = Variable()
+f = Variable()
+const EXPRS = [
+    7,
+    x,
+    :(x + 2y),
+    :(f(x, g(y, z), h(g))),
+    :(f($x, g(y, z), h(g))),
+    :(f($f(x, $x))),
+    :f,
+    :(f()),
+    :(identity(-)(5, 3)),
+    :(a || (b && c)),
+]
+
+
+@testset "Basic"        begin include("basic.jl")        end
 @testset "Substitution" begin include("substitution.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,4 @@ const EXPRS = [
 
 @testset "Basic"        begin include("basic.jl")        end
 @testset "Substitution" begin include("substitution.jl") end
+@testset "Pooling"      begin include("pool.jl")         end

--- a/test/substitution.jl
+++ b/test/substitution.jl
@@ -8,12 +8,10 @@ TermA = Term{Union{Symbol, Int}}
     x = Variable()
     y = Variable()
 
-    subjects = [:a, :(g(a)), :(a + b * f(c)), :([m, n]), x, y]
-
     expr = x
     @testset "$expr" begin
         p = convert(TermA, expr)
-        @testset for k₁ ∈ subjects
+        @testset for k₁ ∈ EXPRS
             s = convert(TermA, k₁)
             σ = match(p, s)
             @test length(σ) == 1
@@ -37,7 +35,7 @@ TermA = Term{Union{Symbol, Int}}
     expr = :($x + k)
     @testset "$expr" begin
         p = convert(TermA, expr)
-        @testset for k₁ ∈ subjects
+        @testset for k₁ ∈ EXPRS
             s = convert(TermA, :($k₁ + k))
             σ = match(p, s)
             @test length(σ) == 1
@@ -51,7 +49,7 @@ TermA = Term{Union{Symbol, Int}}
     expr = :($x - f($y))
     @testset "$expr" begin
         p = convert(TermA, expr)
-        @testset for k₁ ∈ subjects, k₂ ∈ subjects
+        @testset for k₁ ∈ EXPRS, k₂ ∈ EXPRS
             s = convert(TermA, :($k₁ - f($k₂)))
             σ = match(p, s)
             @test length(σ) == 2
@@ -63,7 +61,7 @@ TermA = Term{Union{Symbol, Int}}
     expr = :($x + f($x))
     @testset "$expr" begin
         p = convert(TermA, expr)
-        @testset for k₁ ∈ subjects
+        @testset for k₁ ∈ EXPRS
             s = convert(TermA, :($k₁ + f($k₁)))
             σ = match(p, s)
             @test length(σ) == 1
@@ -75,7 +73,7 @@ TermA = Term{Union{Symbol, Int}}
     expr = :(TypeName{$x, $x, $y})
     @testset "$expr" begin
         p = convert(TermA, expr)
-        @testset for k₁ ∈ subjects, k₂ ∈ subjects
+        @testset for k₁ ∈ EXPRS, k₂ ∈ EXPRS
             s = convert(TermA, expr)
             σ = match(p, s)
             @test length(σ) == 2

--- a/test/substitution.jl
+++ b/test/substitution.jl
@@ -2,7 +2,7 @@ using Terms
 using Test
 
 
-TermA = Pool{Symbol}()
+TermA = Term{Union{Symbol, Int}}
 
 @testset "match" begin
     x = Variable()
@@ -12,9 +12,9 @@ TermA = Pool{Symbol}()
 
     expr = x
     @testset "$expr" begin
-        p = TermA(expr)
+        p = convert(TermA, expr)
         @testset for k₁ ∈ subjects
-            s = TermA(k₁)
+            s = convert(TermA, k₁)
             σ = match(p, s)
             @test length(σ) == 1
             @test σ(p) == s
@@ -23,65 +23,65 @@ TermA = Pool{Symbol}()
 
     expr = :(f())
     @testset "$expr" begin
-        p = TermA(expr)
+        p = convert(TermA, expr)
         @testset begin
-            s = TermA(:(f()))
+            s = convert(TermA, :(f()))
             σ = match(p, s)
             @test isempty(σ)
             @test σ(p) == s
         end
-        @test match(p, TermA(:(g()))) === nothing
-        @test match(p, TermA(:(f(a)))) === nothing
+        @test match(p, convert(TermA, :(g()))) === nothing
+        @test match(p, convert(TermA, :(f(a)))) === nothing
     end
 
     expr = :($x + k)
     @testset "$expr" begin
-        p = TermA(expr)
+        p = convert(TermA, expr)
         @testset for k₁ ∈ subjects
-            s = TermA(:($k₁ + k))
+            s = convert(TermA, :($k₁ + k))
             σ = match(p, s)
             @test length(σ) == 1
             @test σ(p) == s
         end
-        @test match(p, TermA(:(a + b))) === nothing
-        @test match(p, TermA(:(a - k))) === nothing
-        @test match(p, TermA(:(k + $x))) === nothing
+        @test match(p, convert(TermA, :(a + b))) === nothing
+        @test match(p, convert(TermA, :(a - k))) === nothing
+        @test match(p, convert(TermA, :(k + $x))) === nothing
     end
 
     expr = :($x - f($y))
     @testset "$expr" begin
-        p = TermA(expr)
+        p = convert(TermA, expr)
         @testset for k₁ ∈ subjects, k₂ ∈ subjects
-            s = TermA(:($k₁ - f($k₂)))
+            s = convert(TermA, :($k₁ - f($k₂)))
             σ = match(p, s)
             @test length(σ) == 2
             @test σ(p) == s
         end
-        @test match(p, TermA(:(f(a) + b))) === nothing
+        @test match(p, convert(TermA, :(f(a) + b))) === nothing
     end
 
     expr = :($x + f($x))
     @testset "$expr" begin
-        p = TermA(expr)
+        p = convert(TermA, expr)
         @testset for k₁ ∈ subjects
-            s = TermA(:($k₁ + f($k₁)))
+            s = convert(TermA, :($k₁ + f($k₁)))
             σ = match(p, s)
             @test length(σ) == 1
             @test σ(p) == s
         end
-        @test match(p, TermA(:(a + f(b)))) === nothing
+        @test match(p, convert(TermA, :(a + f(b)))) === nothing
     end
 
     expr = :(TypeName{$x, $x, $y})
     @testset "$expr" begin
-        p = TermA(expr)
+        p = convert(TermA, expr)
         @testset for k₁ ∈ subjects, k₂ ∈ subjects
-            s = TermA(expr)
+            s = convert(TermA, expr)
             σ = match(p, s)
             @test length(σ) == 2
             @test σ(p) == s
         end
-        @test match(p, TermA(:(OtherName{a, a, b}))) === nothing
-        @test match(p, TermA(:([a, a, b]))) === nothing
+        @test match(p, convert(TermA, :(OtherName{a, a, b}))) === nothing
+        @test match(p, convert(TermA, :([a, a, b]))) === nothing
     end
 end


### PR DESCRIPTION
Removes requirement that constants are pooled. However, pooling may still be included for efficiency by using `Tree{Union{Symbol, UInt}}` or `Tree{UInt}`.

- [X] Parameterize `Tree`
- [x] Reintroduce pooling as separate feature