### PR TITLE
Redesign API to match Indexing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Terms.jl exports the following features. For the remainder of the document, we a
 using Terms
 ```
 
-Every term `t::Term` represents an abstract syntax tree. We retrieve the root value of `t` using `root(t)` and the child terms using `collect(t)::Vector{Term}`.
+Every term `t::Term` represents an abstract syntax tree. We retrieve the root value of `t` using `root(t)` and the child terms using `children(t)::Vector{Term}`.
 
 ```julia
 k = 2
 t = @term(mod(k ^ 5, 3))  # mod(2 ^ 5, 3)
 
 @assert root(t) == :call
-@assert collect(t) == [@term(mod), @term(k ^ 5), @term 3]
+@assert children(t) == [@term(mod), @term(k ^ 5), @term 3]
 ```
 
 Additionally, we can retrieve a subterm using standard indexing notation, `t[inds...]`.
@@ -32,7 +32,7 @@ Additionally, we can retrieve a subterm using standard indexing notation, `t[ind
 @assert t[2,1] == @term(^)
 ```
 
-#### Example: Leaf Traversal
+#### Example: In-Order Traversal
 
 ```julia
 function leaves(t::Term)

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Terms.jl exports the following features. For the remainder of the document, we a
 using Terms
 ```
 
-Every term `t::Term` represents an abstract syntax tree. We retrieve the root value of `t` using `root(t)` and the child terms using `children(t)::Vector{Term}`.
+Every term `t::Term` represents an abstract syntax tree. We retrieve the root value of `t` using `root(t)` and the child terms using `collect(t)::Vector{Term}`.
 
 ```julia
 k = 2
 t = @term(mod(k ^ 5, 3))  # mod(2 ^ 5, 3)
 
 @assert root(t) == :call
-@assert children(t) == [@term(mod), @term(k ^ 5), @term 3]
+@assert collect(t) == [@term(mod), @term(k ^ 5), @term 3]
 ```
 
 Additionally, we can retrieve a subterm using standard indexing notation, `t[inds...]`.
@@ -32,7 +32,7 @@ Additionally, we can retrieve a subterm using standard indexing notation, `t[ind
 @assert t[2,1] == @term(^)
 ```
 
-#### Example: In-Order Traversal
+#### Example: Leaf Traversal
 
 ```julia
 function leaves(t::Term)

--- a/src/term.jl
+++ b/src/term.jl
@@ -29,14 +29,6 @@ Base.length(t::Term) = length(eachindex(t))
 end
 Base.getindex(t::Term, inds...) = foldl(getindex, inds; init=t)
 
-function _iter(t::Term, next)
-    next === nothing && return
-    i, state = next
-    return (t[i], state)
-end
-Base.iterate(t::Term) = _iter(t, iterate(eachindex(t)))
-Base.iterate(t::Term, state) = _iter(t, iterate(eachindex(t), state))
-
 function Base.map(f, t::Term)
     isa(t.x, Expr) || return t
 

--- a/src/term.jl
+++ b/src/term.jl
@@ -17,11 +17,9 @@ Base.convert(::Type{Expr}, t::Term) = t.x
 Base.:(==)(s::Term, t::Term) = s.x == t.x
 Base.isequal(s::Term, t::Term) = isequal(s.x, t.x)
 
-Base.eltype(::Type{Term}) = Term
 Base.eachindex(t::Term) = isleaf(t) ? Base.OneTo(0) : eachindex(t.x.args)
 Base.firstindex(t::Term) = first(eachindex(t))
 Base.lastindex(t::Term) = last(eachindex(t))
-Base.length(t::Term) = length(eachindex(t))
 
 @inline function Base.getindex(t::Term, i)
     @boundscheck checkindex(Bool, eachindex(t), i) || throw(BoundsError(t, i))

--- a/src/term.jl
+++ b/src/term.jl
@@ -1,5 +1,5 @@
 export Term, @term
-export isleaf, root
+export isleaf, root, children
 
 
 struct Term
@@ -8,6 +8,7 @@ end
 
 @inline isleaf(t::Term) = !isa(t.x, Expr)
 @inline root(t::Term) = isleaf(t) ? t.x : t.x.head
+@inline children(t::Term) = [t[i] for i ∈ eachindex(t)]
 
 Base.convert(::Type{Term}, t::Term) = t
 Base.convert(::Type{Term}, x) = Term(x)
@@ -40,7 +41,7 @@ function Base.map(f, t::Term)
     isa(t.x, Expr) || return t
 
     expr = Expr(root(t))
-    append!(expr.args, map(_unwrap ∘ f, collect(t)))
+    append!(expr.args, map(_unwrap ∘ f, children(t)))
     convert(Term, expr)
 end
 

--- a/src/term.jl
+++ b/src/term.jl
@@ -10,14 +10,6 @@ end
 @inline root(t::Term) = isleaf(t) ? t.x : t.x.head
 @inline children(t::Term) = [t[i] for i ∈ eachindex(t)]
 
-function Base.getindex(t::Term, i)
-    @boundscheck isleaf(t) && throw(BoundsError(t, i))
-    @boundscheck checkbounds(Bool, t.x.args, i) || throw(BoundsError(t, i))
-    return convert(Term, t.x.args[i])
-end
-Base.getindex(t::Term, inds...) = foldl(getindex, inds; init=t)
-Base.eachindex(t::Term) = isleaf(t) ? Base.OneTo(0) : eachindex(t.x.args)
-
 Base.convert(::Type{Term}, t::Term) = t
 Base.convert(::Type{Term}, x) = Term(x)
 Base.convert(::Type{Expr}, t::Term) = t.x
@@ -25,11 +17,31 @@ Base.convert(::Type{Expr}, t::Term) = t.x
 Base.:(==)(s::Term, t::Term) = s.x == t.x
 Base.isequal(s::Term, t::Term) = isequal(s.x, t.x)
 
+Base.eltype(::Type{Term}) = Term
+Base.eachindex(t::Term) = isleaf(t) ? Base.OneTo(0) : eachindex(t.x.args)
+Base.firstindex(t::Term) = first(eachindex(t))
+Base.lastindex(t::Term) = last(eachindex(t))
+Base.length(t::Term) = length(eachindex(t))
+
+@inline function Base.getindex(t::Term, i)
+    @boundscheck checkindex(Bool, eachindex(t), i) || throw(BoundsError(t, i))
+    return convert(Term, t.x.args[i])
+end
+Base.getindex(t::Term, inds...) = foldl(getindex, inds; init=t)
+
+function _iter(t::Term, next)
+    next === nothing && return
+    i, state = next
+    return (t[i], state)
+end
+Base.iterate(t::Term) = _iter(t, iterate(eachindex(t)))
+Base.iterate(t::Term, state) = _iter(t, iterate(eachindex(t), state))
+
 function Base.map(f, t::Term)
     isa(t.x, Expr) || return t
 
     expr = Expr(root(t))
-    append!(expr.args, map(t -> (f(t)::Term).x, children(t)))
+    append!(expr.args, map(_unwrap ∘ f, collect(t)))
     convert(Term, expr)
 end
 

--- a/src/term.jl
+++ b/src/term.jl
@@ -1,5 +1,5 @@
 export Term, @term
-export isleaf, root, children
+export isleaf, root
 
 
 struct Term
@@ -8,7 +8,6 @@ end
 
 @inline isleaf(t::Term) = !isa(t.x, Expr)
 @inline root(t::Term) = isleaf(t) ? t.x : t.x.head
-@inline children(t::Term) = [t[i] for i ∈ eachindex(t)]
 
 Base.convert(::Type{Term}, t::Term) = t
 Base.convert(::Type{Term}, x) = Term(x)

--- a/test/term.jl
+++ b/test/term.jl
@@ -74,6 +74,8 @@ end
     function test_tree(ex::Expr, t::Term)
         @test root(t) === ex.head
         @test eachindex(t) == 1:length(ex.args)
+        @test firstindex(t) == 1
+        @test lastindex(t) == length(ex.args)
         @test length(children(t)) == length(ex.args)
         @test eltype(children(t)) <: Term
 

--- a/test/term.jl
+++ b/test/term.jl
@@ -10,26 +10,26 @@ using Test
     @test root(t1) === x
     @test isleaf(t1)
     @test isempty(eachindex(t1))
-    @test isempty(children(t1))
+    @test isempty(collect(t1))
     @test_throws BoundsError(t1, 1) t1[1]
 
     t2 = @term(k)
     @test root(t2) === k
     @test isleaf(t2)
     @test isempty(eachindex(t2))
-    @test isempty(children(t2))
+    @test isempty(collect(t2))
 
     t3 = @term("test")
     @test root(t3) == "test"
     @test isleaf(t3)
     @test isempty(eachindex(t3))
-    @test isempty(children(t3))
+    @test isempty(collect(t3))
 
     t4 = @term(x^2 + k)
     @test root(t4) === :call
     @test !isleaf(t4)
     @test eachindex(t4) == 1:3
-    @test children(t4) == [@term(+), @term(x^2), @term(k)]
+    @test collect(t4) == [@term(+), @term(x^2), @term(k)]
     @test t4[1] == @term(+)
     @test t4[2] == @term(x^2)
     @test t4[2,3] == t4[2][3] == @term(2)
@@ -52,7 +52,7 @@ Base.convert(::Type{Term}, w::WrapperTest) = w.t
     t = @term(a ^ b)
 
     @test root(t) === :call
-    @test children(t) == [@term(^), a, b]
+    @test collect(t) == [@term(^), a, b]
     @test t == @term((1 + 2) ^ 3)
 
     @test @term(1 + $(@term(sin(2)))) == @term(1 + sin(2))
@@ -60,7 +60,7 @@ Base.convert(::Type{Term}, w::WrapperTest) = w.t
     w = WrapperTest(@term(sin(2a)))
     t2 = @term(w + 1)
     @test root(t2) === :call
-    @test children(t2) == [@term(+), @term(sin(2*(1+2))), @term(1)]
+    @test collect(t2) == [@term(+), @term(sin(2*(1+2))), @term(1)]
     @test t2 == @term(sin(2*(1+2)) + 1)
 end
 
@@ -74,17 +74,17 @@ end
     function test_tree(ex::Expr, t::Term)
         @test root(t) === ex.head
         @test eachindex(t) == 1:length(ex.args)
-        @test length(children(t)) == length(ex.args)
-        @test eltype(children(t)) <: Term
+        @test length(collect(t)) == length(ex.args)
+        @test eltype(collect(t)) <: Term
 
-        test_tree.(ex.args, children(t))
+        test_tree.(ex.args, collect(t))
         nothing
     end
     function test_tree(x, t::Term)
         @test root(t) === x
         @test isempty(eachindex(t))
-        @test isempty(children(t))
-        @test eltype(children(t)) <: Term
+        @test isempty(collect(t))
+        @test eltype(collect(t)) <: Term
         nothing
     end
 

--- a/test/term.jl
+++ b/test/term.jl
@@ -10,26 +10,26 @@ using Test
     @test root(t1) === x
     @test isleaf(t1)
     @test isempty(eachindex(t1))
-    @test isempty(collect(t1))
+    @test isempty(children(t1))
     @test_throws BoundsError(t1, 1) t1[1]
 
     t2 = @term(k)
     @test root(t2) === k
     @test isleaf(t2)
     @test isempty(eachindex(t2))
-    @test isempty(collect(t2))
+    @test isempty(children(t2))
 
     t3 = @term("test")
     @test root(t3) == "test"
     @test isleaf(t3)
     @test isempty(eachindex(t3))
-    @test isempty(collect(t3))
+    @test isempty(children(t3))
 
     t4 = @term(x^2 + k)
     @test root(t4) === :call
     @test !isleaf(t4)
     @test eachindex(t4) == 1:3
-    @test collect(t4) == [@term(+), @term(x^2), @term(k)]
+    @test children(t4) == [@term(+), @term(x^2), @term(k)]
     @test t4[1] == @term(+)
     @test t4[2] == @term(x^2)
     @test t4[2,3] == t4[2][3] == @term(2)
@@ -52,7 +52,7 @@ Base.convert(::Type{Term}, w::WrapperTest) = w.t
     t = @term(a ^ b)
 
     @test root(t) === :call
-    @test collect(t) == [@term(^), a, b]
+    @test children(t) == [@term(^), a, b]
     @test t == @term((1 + 2) ^ 3)
 
     @test @term(1 + $(@term(sin(2)))) == @term(1 + sin(2))
@@ -60,7 +60,7 @@ Base.convert(::Type{Term}, w::WrapperTest) = w.t
     w = WrapperTest(@term(sin(2a)))
     t2 = @term(w + 1)
     @test root(t2) === :call
-    @test collect(t2) == [@term(+), @term(sin(2*(1+2))), @term(1)]
+    @test children(t2) == [@term(+), @term(sin(2*(1+2))), @term(1)]
     @test t2 == @term(sin(2*(1+2)) + 1)
 end
 
@@ -74,17 +74,17 @@ end
     function test_tree(ex::Expr, t::Term)
         @test root(t) === ex.head
         @test eachindex(t) == 1:length(ex.args)
-        @test length(collect(t)) == length(ex.args)
-        @test eltype(collect(t)) <: Term
+        @test length(children(t)) == length(ex.args)
+        @test eltype(children(t)) <: Term
 
-        test_tree.(ex.args, collect(t))
+        test_tree.(ex.args, children(t))
         nothing
     end
     function test_tree(x, t::Term)
         @test root(t) === x
         @test isempty(eachindex(t))
-        @test isempty(collect(t))
-        @test eltype(collect(t)) <: Term
+        @test isempty(children(t))
+        @test eltype(children(t)) <: Term
         nothing
     end
 


### PR DESCRIPTION
Follow [Indexing interface](https://docs.julialang.org/en/latest/manual/interfaces/#Indexing-1).